### PR TITLE
Patch to Neo4J Connector to depend on retro Senzing Listener and pre-3.0 g2.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /target/
 .classpath
 /.settings/
+*.iml
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-listener</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <version>0.0.1</version>
     </dependency>
     <!-- tag::bolt-dependency[] -->
     <dependency>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>g2</artifactId>
-      <version>[1.14.0-SNAPSHOT,)</version>
+      <version>[1.14.0-SNAPSHOT,2.999.999)</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>


### PR DESCRIPTION
Changes to pom.xml to limit the dependency on `g2.jar` to versions prior to `3.0` pre-release betas (maximum version is now `2.999.999`).

Also changed dependency on `Senzing-listener` to change version from `0.0.1-SNAPSHOT` to the retroactive version `0.0.1` release that did not previously exist except as the head of the main branch at a particular point in time.