### PR TITLE
Remove JSON fields that no longer appear in G2 output documents in 3.0

### DIFF
--- a/src/main/java/com/senzing/neo4j/connector/data/g2/G2Entity.java
+++ b/src/main/java/com/senzing/neo4j/connector/data/g2/G2Entity.java
@@ -24,36 +24,31 @@ public class G2Entity {
   // Entity fields
   public static final String ENTITY_ID_FIELD = "ENTITY_ID";
   private final static String ENTITY_NAME = "ENTITY_NAME";
-  private static final String ENTITY_LENS_CODE = "LENS_CODE";
   private static final String ENTITY_TYPE = "ENTITY_TYPE";
   private static final String ENTITY_FEAT_DESC = "FEAT_DESC";
-  private static final String[] ENTITY_FIELDS = { ENTITY_ID_FIELD, ENTITY_NAME, ENTITY_LENS_CODE };
+  private static final String[] ENTITY_FIELDS = { ENTITY_ID_FIELD, ENTITY_NAME };
 
   // Relationship fields
   private static final String RELATIONSHIP_MATCH_KEY = "MATCH_KEY";
   private static final String RELATIONSHIP_MATCH_LEVEL = "MATCH_LEVEL";
   private static final String RELATIONSHIP_MATCH_LEVEL_CODE = "MATCH_LEVEL_CODE";
-  private static final String RELATIONSHIP_MATCH_SCORE = "MATCH_SCORE";
   private static final String RELATIONSHIP_ERRULE_CODE = "ERRULE_CODE";
-  private static final String RELATIONSHIP_REF_SCORE = "REF_SCORE";
   private static final String RELATIONSHIP_IS_DISCLOSED = "IS_DISCLOSED";
   private static final String RELATIONSHIP_IS_AMBIGUOUS = "IS_AMBIGUOUS";
   private static final String[] RELATIONSHIP_FIELDS = { RELATIONSHIP_MATCH_KEY, RELATIONSHIP_MATCH_LEVEL,
-      RELATIONSHIP_MATCH_LEVEL_CODE, RELATIONSHIP_MATCH_SCORE, RELATIONSHIP_ERRULE_CODE, RELATIONSHIP_REF_SCORE,
-      RELATIONSHIP_IS_DISCLOSED, RELATIONSHIP_IS_AMBIGUOUS };
+      RELATIONSHIP_MATCH_LEVEL_CODE, RELATIONSHIP_ERRULE_CODE, RELATIONSHIP_IS_DISCLOSED, 
+      RELATIONSHIP_IS_AMBIGUOUS };
 
   // Record fields
   public static final String RECORD_ID_FIELD = "RECORD_ID";
   public static final String RECORD_DATA_SOURCE = "DATA_SOURCE";
   private static final String RECORD_MATCH_KEY = "MATCH_KEY";
-  private static final String RECORD_MATCH_SCORE = "MATCH_SCORE";
   private static final String RECORD_ERRULE_CODE = "ERRULE_CODE";
-  private static final String RECORD_REF_SCORE = "REF_SCORE";
   private static final String RECORD_MATCH_LEVEL = "MATCH_LEVEL";
   private static final String RECORD_MATCH_LEVEL_CODE = "MATCH_LEVEL_CODE";
   private static final String G2_RECORD_ID_FIELD = "INTERNAL_ID";
   private static final String[] RECORD_FIELDS = { RECORD_ID_FIELD, RECORD_DATA_SOURCE, RECORD_MATCH_KEY,
-      RECORD_MATCH_SCORE, RECORD_ERRULE_CODE, RECORD_REF_SCORE, RECORD_MATCH_LEVEL, RECORD_MATCH_LEVEL_CODE };
+      RECORD_ERRULE_CODE, RECORD_MATCH_LEVEL, RECORD_MATCH_LEVEL_CODE };
 
   private Long entityId;
   private String entityType;

--- a/src/test/java/com/senzing/neo4j/connector/data/g2/G2EntityTest.java
+++ b/src/test/java/com/senzing/neo4j/connector/data/g2/G2EntityTest.java
@@ -36,68 +36,58 @@ public class G2EntityTest {
     assertThat(g2Entity.getRecords(), is(notNullValue()));
     assertThat(g2Entity.getRelationships(), is(notNullValue()));
 
-    assertThat(g2Entity.getFeatures().size(), is(equalTo(9)));
+    assertThat(g2Entity.getFeatures().size(), is(equalTo(8)));
     assertThat(g2Entity.getRecords().size(), is(equalTo(3)));
     assertThat(g2Entity.getRelationships().size(), is(equalTo(3)));
 
-    assertThat(g2Entity.getFeatures().get("LENS_CODE"), is(equalTo("DEFAULT")));
     assertThat(g2Entity.getFeatures().get("ENTITY_NAME"), is(equalTo("JENNY SMITH")));
 
     assertThat(g2Entity.getRecords().get(2L), is(notNullValue()));
     assertThat(g2Entity.getRecords().get(4L), is(notNullValue()));
     assertThat(g2Entity.getRecords().get(6L), is(notNullValue()));
 
-    assertThat(g2Entity.getRecords().get(2L).size(), is(equalTo(4)));
-    assertThat(g2Entity.getRecords().get(4L).size(), is(equalTo(8)));
-    assertThat(g2Entity.getRecords().get(6L).size(), is(equalTo(8)));
+    assertThat(g2Entity.getRecords().get(2L).size(), is(equalTo(3)));
+    assertThat(g2Entity.getRecords().get(4L).size(), is(equalTo(6)));
+    assertThat(g2Entity.getRecords().get(6L).size(), is(equalTo(6)));
 
     assertThat(g2Entity.getRecords().get(2L).get("DATA_SOURCE"), is(equalTo("PEOPLE")));
     assertThat(g2Entity.getRecords().get(2L).get("RECORD_ID"), is(equalTo("1001-2")));
-    assertThat(g2Entity.getRecords().get(2L).get("REF_SCORE"), is(equalTo(0)));
     assertThat(g2Entity.getRecords().get(2L).get("MATCH_LEVEL"), is(equalTo(0)));
 
     assertThat(g2Entity.getRecords().get(4L).get("DATA_SOURCE"), is(equalTo("PEOPLE")));
     assertThat(g2Entity.getRecords().get(4L).get("RECORD_ID"), is(equalTo("1002-2")));
-    assertThat(g2Entity.getRecords().get(4L).get("REF_SCORE"), is(equalTo(8)));
     assertThat(g2Entity.getRecords().get(4L).get("MATCH_LEVEL"), is(equalTo(1)));
 
     assertThat(g2Entity.getRecords().get(6L).get("DATA_SOURCE"), is(equalTo("PEOPLE")));
     assertThat(g2Entity.getRecords().get(6L).get("RECORD_ID"), is(equalTo("1003-2")));
-    assertThat(g2Entity.getRecords().get(2L).get("REF_SCORE"), is(equalTo(0)));
     assertThat(g2Entity.getRecords().get(6L).get("MATCH_LEVEL"), is(equalTo(1)));
 
     assertThat(g2Entity.getRelationships().get(1001L), is(notNullValue()));
     assertThat(g2Entity.getRelationships().get(1002L), is(notNullValue()));
     assertThat(g2Entity.getRelationships().get(1003L), is(notNullValue()));
 
-    assertThat(g2Entity.getRelationships().get(1001L).size(), is(equalTo(8)));
-    assertThat(g2Entity.getRelationships().get(1002L).size(), is(equalTo(8)));
-    assertThat(g2Entity.getRelationships().get(1003L).size(), is(equalTo(8)));
+    assertThat(g2Entity.getRelationships().get(1001L).size(), is(equalTo(6)));
+    assertThat(g2Entity.getRelationships().get(1002L).size(), is(equalTo(6)));
+    assertThat(g2Entity.getRelationships().get(1003L).size(), is(equalTo(6)));
 
     assertThat(g2Entity.getRelationships().get(1001L).get("MATCH_LEVEL"), is(equalTo(11)));
     assertThat(g2Entity.getRelationships().get(1001L).get("MATCH_LEVEL_CODE"), is(equalTo("DISCLOSED")));
     assertThat(g2Entity.getRelationships().get(1001L).get("MATCH_KEY"), is(equalTo("+OWNERSHIP")));
-    assertThat(g2Entity.getRelationships().get(1001L).get("MATCH_SCORE"), is(equalTo("10")));
     assertThat(g2Entity.getRelationships().get(1001L).get("ERRULE_CODE"), is(equalTo("DISCLOSED")));
-    assertThat(g2Entity.getRelationships().get(1001L).get("REF_SCORE"), is(equalTo(0)));
     assertThat(g2Entity.getRelationships().get(1001L).get("IS_DISCLOSED"), is(equalTo(1)));
     assertThat(g2Entity.getRelationships().get(1001L).get("IS_AMBIGUOUS"), is(equalTo(0)));
 
     assertThat(g2Entity.getRelationships().get(1002L).get("MATCH_LEVEL"), is(equalTo(11)));
     assertThat(g2Entity.getRelationships().get(1002L).get("MATCH_LEVEL_CODE"), is(equalTo("DISCLOSED")));
     assertThat(g2Entity.getRelationships().get(1002L).get("MATCH_KEY"), is(equalTo("+OWNERSHIP")));
-    assertThat(g2Entity.getRelationships().get(1002L).get("MATCH_SCORE"), is(equalTo("10")));
     assertThat(g2Entity.getRelationships().get(1002L).get("ERRULE_CODE"), is(equalTo("DISCLOSED")));
-    assertThat(g2Entity.getRelationships().get(1002L).get("REF_SCORE"), is(equalTo(0)));
     assertThat(g2Entity.getRelationships().get(1002L).get("IS_DISCLOSED"), is(equalTo(1)));
     assertThat(g2Entity.getRelationships().get(1002L).get("IS_AMBIGUOUS"), is(equalTo(0)));
 
     assertThat(g2Entity.getRelationships().get(1003L).get("MATCH_LEVEL"), is(equalTo(11)));
     assertThat(g2Entity.getRelationships().get(1003L).get("MATCH_LEVEL_CODE"), is(equalTo("DISCLOSED")));
     assertThat(g2Entity.getRelationships().get(1003L).get("MATCH_KEY"), is(equalTo("+OWNERSHIP")));
-    assertThat(g2Entity.getRelationships().get(1003L).get("MATCH_SCORE"), is(equalTo("10")));
     assertThat(g2Entity.getRelationships().get(1003L).get("ERRULE_CODE"), is(equalTo("DISCLOSED")));
-    assertThat(g2Entity.getRelationships().get(1003L).get("REF_SCORE"), is(equalTo(0)));
     assertThat(g2Entity.getRelationships().get(1003L).get("IS_DISCLOSED"), is(equalTo(1)));
     assertThat(g2Entity.getRelationships().get(1003L).get("IS_AMBIGUOUS"), is(equalTo(0)));
 


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #nnn

## Why was change needed

fields were removed from G2 output JSON documents which broke connector-neo4j because they were considered required fields

## What does change improve

project now runs without errors
